### PR TITLE
Upgrade to mongodb 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
 RUN dpkg-divert --local --rename --add /sbin/initctl
 RUN ln -s /bin/true /sbin/initctl
-RUN apt-get update
-RUN apt-get install -y mongodb-10gen
+RUN apt-get update && apt-get install -y mongodb-org
 
 # Create default MongoDB data directory.
 RUN mkdir -p /data/db


### PR DESCRIPTION
A new version of mongodb has been released and this is the new recommended installation method [1].

[1] http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/#install-the-latest-stable-version-of-mongodb-enterprise
