### PR TITLE
Added documentation for usage with VirtualBox (boot2docker-vm).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,20 @@ This repository contains **Dockerfile** of [MongoDB](http://www.mongodb.org/) fo
 
 #### Run `mongod` w/ persistent/shared directory
 
-    docker run -d -p 27017:27017 -v <data-dir>:/data --name mongodb dockerfile/mongodb
+    docker run -d -p 27017:27017 -v <data-dir>/db:/data/db --name mongodb dockerfile/mongodb
 
 #### Run `mongod` w/ HTTP support (requires firewall on port 28017)
 
     docker run -d -p 27017:27017 -p 28017:28017 --name mongodb dockerfile/mongodb mongod --rest --httpinterface
 
 #### Run `mongo`
-
+    
     docker run -it --rm --link mongodb:mongodb dockerfile/mongodb bash -c 'mongo --host $MONGODB_PORT_27017_TCP_ADDR'
+
+##### Usage with VirtualBox (boot2docker-vm)
+
+_You will need to set up nat port forwarding with:_  
+
+    VBoxManage modifyvm "boot2docker-vm" --natpf1 "guestmongodb,tcp,127.0.0.1,27017,,27017"  
+    
+This will allow you to connect to your mongo container with the standard 'mongo' commands  


### PR DESCRIPTION
Modified/updated documentation 
- Added '/db' to the persistent/shared directory command (the container logs were complaining on startup) 
- Added usage hint for Virtualbox, specifically around port forwarding.  
