### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ This repository contains **Dockerfile** of [MongoDB](http://www.mongodb.org/) fo
 
    (alternatively, you can build an image from Dockerfile: `docker build -t="dockerfile/mongodb" github.com/dockerfile/mongodb`)
 
+##### Usage with VirtualBox (boot2docker-vm)
+
+_You will need to set up nat port forwarding with:_  
+
+    VBoxManage modifyvm "boot2docker-vm" --natpf1 "guestmongodb,tcp,127.0.0.1,27017,,27017"
+
+_If boot2docker is already running:_
+
+    boot2docker stop && VBoxManage modifyvm "boot2docker-vm" --natpf1 "guestmongodb,tcp,127.0.0.1,27017,,27017" && boot2docker restart
+
+This will allow you to connect to your mongo container with the standard `mongo` commands.
 
 ### Usage
 
@@ -39,11 +50,3 @@ This repository contains **Dockerfile** of [MongoDB](http://www.mongodb.org/) fo
 #### Run `mongo`
 
     docker run -it --rm --link mongodb:mongodb dockerfile/mongodb bash -c 'mongo --host mongodb'
-
-##### Usage with VirtualBox (boot2docker-vm)
-
-_You will need to set up nat port forwarding with:_  
-
-    VBoxManage modifyvm "boot2docker-vm" --natpf1 "guestmongodb,tcp,127.0.0.1,27017,,27017"
-
-This will allow you to connect to your mongo container with the standard `mongo` commands.


### PR DESCRIPTION
move position of boot2docker related nat forwarding to a more clear area of the instructions 
- it took me forever to see this when i was setting things up, and i felt like a dolt for having missed it
